### PR TITLE
Upgrade the version of Finagle, Ostrich & Util

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,37 +68,37 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>finagle-http</artifactId>
-      <version>5.0.3</version>
+      <version>5.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>finagle-kestrel</artifactId>
-      <version>5.0.3</version>
+      <version>5.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>finagle-memcached</artifactId>
-      <version>5.0.3</version>
+      <version>5.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>finagle-ostrich4</artifactId>
-      <version>5.0.3</version>
+      <version>5.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>finagle-thrift</artifactId>
-      <version>5.0.3</version>
+      <version>5.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>ostrich</artifactId>
-      <version>8.1.0</version>
+      <version>8.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>util-core</artifactId>
-      <version>5.2.0</version>
+      <version>5.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>


### PR DESCRIPTION
This pulls them to current released versions from maven.twttr.com.
