### PR TITLE
rm 404 links. pull in some explanations from groups discussion.

### DIFF
--- a/components.html
+++ b/components.html
@@ -76,19 +76,22 @@
         <p class="lead">While Iago attempts to make life simple for developers, there's a lot
 happening under the hood to accomplish that goal.</p>
       </header>
-      <p>Server - This sends traffic to the system under test, as well as logging critical
-      metrics such as response time. The Server is horizontally scalaable -- you can have
+      <p><strong>Server</strong> sends traffic to the system under test, as well as logging critical
+      metrics such as response time. The Server is horizontally scalable&emdash;you can have
       one or hundreds if you desire. The amount of traffic one Server can generate is
       dependent on a wide variety of factors including how many request per second it can
       build, the amount of bandwidth a request needs, the response time of your service vis
       a vis the number of ephemeral sockets available, etc. At Twitter we regularly find that
       an untuned Server can support anywhere from 5K to 10K rps, provided requests are
       straightforward to create.</p>
-      <p>Feeder - This sends log lines to the Server. It can speak to multiple Servers, and
+      <p><strong>Feeder</strong> sends log lines to the Server.
+      It can speak to multiple Servers, and
       itself is also horizontally scalable if for some reason there is a bottleneck getting
       the raw data  used to create requests to the Server. Typically the Feeder logs are the
       first place to look to troubleshoot Iago.</p>
-      <p>Launcher - This provides the primary method of launching the Feeder and Server. It is
+      <p><strong>Launcher</strong> launches the Feeder and Server. If you're running one server
+      and one feeder, this might be simple; but if you're launching feeders and servers on several
+      machines, the launcher has more to do. It is
       extensible, in that you can plug your own behavior into the Launcher relatively easily.
       At Twitter, it plugs into our grid computing system, Mesos, as well as integrating
       naturally with HDFS. In local mode, it assumes you can run a load test from the system

--- a/css/bootstrap.css
+++ b/css/bootstrap.css
@@ -156,7 +156,7 @@ body {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 13px;
   line-height: 18px;
-  color: #333333;
+  color: #000;
   background-color: #ffffff;
 }
 

--- a/index.html
+++ b/index.html
@@ -80,17 +80,39 @@
     <p>A load generator, built for engineers.</p>
     <p class="download-info">
       <a href="https://github.com/twitter/iago/" class="btn btn-primary btn-large">View project on GitHub</a>
-      <a href="assets/iago.zip" class="btn btn-large">Download Iago <small>(v0.5.0)</small></a>
+      <a href="https://github.com/twitter/iago/zipball/master" class="btn btn-large">Download Iago <small>(and docs)</small></a>
     </p>
   </div>
 
   <div class="bs-links">
     <ul class="quick-links">
-      <li><a href="https://github.com/twitter/iago/zipball/master">Download with docs</a></li>
-      <li><a href="http://blog.iago.twitter.com">Read the blog</a></li>
+      <li><a href="https://groups.google.com/forum/#!forum/iago-users">Discuss</a></li>
+
       <li><a href="https://github.com/twitter/iago/issues?state=open">Submit issues</a></li>
-      <li><a href="https://github.com/twitter/iago/wiki">Roadmap and changelog</a></li>
     </ul>
+
+    <ul class="quick-links">
+              <li class="">
+                <a href="./philosophy.html"
+                   title="What problem does Iago solve?">Philosophy</a>
+              </li>
+              <li class="">
+                <a href="./protocols.html">Protocols</a>
+              </li>
+              <li class="">
+                <a href="./components.html">Components</a>
+              </li>
+              <li class="">
+                <a href="./log_sources.html">Log Sources</a>
+              </li>
+              <li class="">
+                <a href="./extending.html">Extending</a>
+              </li>
+              <li class="">
+                <a href="./examples.html">Examples</a>
+              </li>
+    </ul>
+
     <ul class="quick-links">
       <li>
         <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twitter&repo=iago&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="112px" height="20px"></iframe>

--- a/philosophy.html
+++ b/philosophy.html
@@ -73,43 +73,54 @@
     <div class="container">
       <header class="jumbotron subhead" id="overview">
         <h1>Philosophy</h1>
-        <p class="lead">Iago has a specific point of view about load testing. Understanding 
-          that point of view will help in making a decision to use it.</p>
-        <p>First of all, Iago is primarily a load generation library. It is designed
-          to be used by software engineers who have some familiarity with a JVM language such as
-          Java or Scala. While it's possible to use Iago as a stand-alone load testing application,
-          this is not its strong suit today and you will probably be happier with other tools
-          if that is what you need.</p>
-        <p>That said, it is also designed to be very easy to use. It usually requires
+        <p class="lead">Iago has a specific point of view about load testing. Understanding
+          that point of view will help you to decide whether to use it.</p>
+        <p>Iago is primarily a load generation library. It is designed
+          for software engineers familiar with a JVM language such as
+          Java or Scala. If you want to test an API under load, Iago is great.
+          While you can use Iago as a stand-alone load testing application,
+          this is not its strong suit today; if that is what you want, you will probably be
+          happier with other tools.</p>
+        <p>That said, if you are a programmer who wants to test an API under load, Iago is very easy
+           to use. Stand-alone load-test applications are great if you want to repeatedly get
+           http://example.com/, but if you instead want to repeatedly exercise an API, they
+           probably don't do what you want. Iago shines here.
+        <p>If you've already written a test client for your API, you've probably already written
+          the code that Iago can use to exercise that API. It usually requires
           more code to write a test client than it does to write a load test using Iago. Indeed,
           the code from a test client is usually just what you need to write your load test. This
           is deliberate, because we believe that people who most need Iago are those who find
-          themselves writing their own load tests late at night after a release has gone bad.
-          Use Iago, it's easier!</p>
-        <p>Another strong suit of Iago is its ability to accurately replicate production traffic,
-          with a heavy emphasis on modelling open systems (ie, systems which recieve requests
-          independent of their ability to service them). Unlike many open source and commercially
-          available load generators, Iago does not attempt to model users with threads, has no
-          concept of think time, and is not particularly amenable to characterizing load in terms
-          of concurrent users</p>
-        </p>Instead, Iago focuses on requests per second and has built-in support for statistical
-          models such as an exponential distribution (used to model a Poisson Process), uniform
-          distributions, as well as supporting easily writing your own request distribution either
-          in terms of sums of distribution or your own implementation. Under the hood, Iago goes
-          the extra mile in terms of reliably meeting the arrival times your distribution specifies,
+          themselves writing their own load tests late at night after a release has gone bad.</p>
+        <p>Iago accurately replicates production traffic. It models open systems,
+          systems which recieve requests independent of their ability to service them.
+          Typical load generators measure the
+          time it takes for <var>M</var> threads to make <var>N</var> requests, waiting for a
+          response to each request before sending the next; if your system slows down under load,
+          these load testers thus mercifully slow down their pace to match.
+          That's a fine thing to measure; many systems behave this way. But maybe your
+          service isn't such a system; maybe it's exposed on the internet.
+          Maybe you want to know how your system behaves when <var>N</var>
+          requests per second come in with no "mercy" if it slows down.</p>
+        <p>Iago focuses on requests per second and has built-in support for statistical
+          models such as an exponential distribution (used to model a Poisson Process) and uniform
+          distributions. You can also write your own request distribution, either
+          in terms of sums of distribution or your own implementation. Iago
+          reliably meets the arrival times your distribution specifies,
           even when rates and wait times are high.</p>
-        <p>Speaking of high request rates, Iago supports arbitrarily high rates of traffic via
-          built-in support for creating clusters. At Twitter, engineers regularly run load tests
+        <p>Iago supports arbitrarily high rates of traffic via
+          built-in support for creating clusters: if one machine can't generate the load you need,
+          then Iago can launch jobs on more machines. At Twitter, engineers regularly run load tests
           that generate in excess of 100K requests per second or more. Single instances of Iago
           can easily achieve anywhere from 1K to 10K rps from commodity hardware, only limited by
           the particulars of your protocol needs.</p>
-        <p>Equally important is Iago's ability to be extended. Because our target users are other
-          engineers, it is critical that every possible knob be available to turn. In fact, you
-          can easily write your own knobs, protocols, data sources, management interfaces or
-          whatever else you can imagine because Iago's components are designed from the ground
-          up to be extended or replaced.
-        <p>In short, Iago is the load generator we used to wish we had. Now that we've written
-          it, we want to share it with like-minded engineers who appreciate its capabilities.</p>
+        <p>You can extend or replace Iago's components. Because our target users are other
+          engineers, it is critical that every knob be available to turn. You
+          can write your own protocols, data sources, management interfaces or
+          whatever else you can imagine.
+        <p>Iago is the load generator we wished for. Now that we have it,
+          we want to share it with like-minded engineers who appreciate its capabilities.
+          To get started with Iago, <a href="https://github.com/twitter/iago/">view it on
+          Github, download it, and read its README</a>.</p>
       </header>
     </div><!-- /container -->
 


### PR DESCRIPTION
Remove some 404 links. Replace big-button 404 link (oy veh) with a working
one. Link to groups discussion. Add links to sub-pages from top page that
you'll see even if you don't notice the black bar up top.
Tweak main text color CSS so more folks can read the text. Pull some
what-problem-Iago-solves text from the discussion group and put it on the
philosophy page. Link from phil page to Github in case we convinced you
to use it and you're wondering what to do next. Don't put the version
number here; I don't want to maintain that and I bet you don't either.
Typo fixes.
