### PR TITLE
Fix parrot-feeder and parrot-server shell scripts on Ubuntu

### DIFF
--- a/src/main/resources/scripts/parrot-feeder.sh
+++ b/src/main/resources/scripts/parrot-feeder.sh
@@ -21,7 +21,7 @@ DEBUG_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=500
 JAVA_OPTS="-server $GC_OPTS $HEAP_OPTS $PROFILE_OPTS" #$DEBUG_OPTS"
 
 # Used to set JAVA_HOME sanely if not already set.
-function find_java {
+find_java () {
   if [ ! -z $JAVA_HOME ]; then
     return
   fi

--- a/src/main/resources/scripts/parrot-server.sh
+++ b/src/main/resources/scripts/parrot-server.sh
@@ -20,7 +20,7 @@ DEBUG_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=500
 JAVA_OPTS="-server $GC_OPTS $HEAP_OPTS $PROFILE_OPTS" # $DEBUG_OPTS"
 
 # Used to set JAVA_HOME sanely if not already set.
-function find_java {
+find_java () {
   if [ ! -z $JAVA_HOME ]; then
     return
   fi


### PR DESCRIPTION
On Ubuntu 13.04, I am unable to run either parrot-feeder.sh or parrot-server.sh.  I believe the problem stems from the usage of the deprecated 'function' keyword.  Removing the deprecated keyword fixed the problem and should make the scripts more portable.  See http://wiki.bash-hackers.org/scripting/obsolete for additional information.
