### PR TITLE
Remove bash-ism.

### DIFF
--- a/src/main/resources/scripts/common.sh
+++ b/src/main/resources/scripts/common.sh
@@ -1,6 +1,6 @@
 # common.sh
 
-if [[ -z $JAVA_HOME ]]; then
+if [ -z "$JAVA_HOME" ]; then
   potential=$(ls -r1d /usr/lib/jvm/java-1.7.0-openjdk7 /opt/jdk /System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK/Home /usr/java/default /usr/java/j* 2>/dev/null)
   for p in $potential; do
     if [ -x $p/bin/java ]; then


### PR DESCRIPTION
Hi, I found a bash-ism in scripts/common.sh on Ubuntu 13.04 (where /bin/sh is dash by default).
