### PR TITLE
fix to ensure config.recordProcessor.start() gets called

### DIFF
--- a/src/main/scala/com/twitter/parrot/server/ParrotServer.scala
+++ b/src/main/scala/com/twitter/parrot/server/ParrotServer.scala
@@ -62,6 +62,7 @@ class ParrotServerImpl[Req <: ParrotRequest, Rep](val config: ParrotServerConfig
     clusterService.start(config.parrotPort)
     status.setStatus(ParrotState.RUNNING)
     log.info("using record processor %s", config.recordProcessor.getClass().getName())
+    config.recordProcessor.start()
     Future.Void
   }
 


### PR DESCRIPTION
One line fix for https://github.com/twitter/iago/issues/19
