### PR TITLE
Make random X-Forwarded-For header configurable.

### DIFF
--- a/src/main/resources/templates/template-server.scala.in
+++ b/src/main/resources/templates/template-server.scala.in
@@ -41,6 +41,7 @@ new #{configType}[#{requestType}, #{responseType}] {
   requestTimeoutInMs = #{requestTimeoutInMs}
   tcpConnectTimeoutInMs = #{tcpConnectTimeoutInMs}
   includeParrotHeader = #{includeParrotHeader}
+  includeRandomXForwardedForHeader = #{includeRandomXForwardedForHeader}
 
   // for thrift
   parrotPort = 9999

--- a/src/main/scala/com/twitter/parrot/config/ParrotLauncherConfig.scala
+++ b/src/main/scala/com/twitter/parrot/config/ParrotLauncherConfig.scala
@@ -38,6 +38,8 @@ trait ParrotLauncherConfig extends Config[ParrotLauncher] with ParrotCommonConfi
   var hostConnectionLimit = Integer.MAX_VALUE
   var hostConnectionMaxIdleTimeInMs = 300000 // 5m
   var hostConnectionMaxLifeTimeInMs = Integer.MAX_VALUE
+  var includeParrotHeader = true
+  var includeRandomXForwardedForHeader = true
   var jobName = required[String]
   var localMode = false
   var log = required[String]
@@ -62,7 +64,6 @@ trait ParrotLauncherConfig extends Config[ParrotLauncher] with ParrotCommonConfi
   var timeUnit = "MINUTES"
   var traceLevel: Level = Level.INFO
   var verboseCmd = false
-  var includeParrotHeader = true
   var mesosFeederNumCpus = 5.0
   var mesosServerNumCpus = 4.0
 

--- a/src/main/scala/com/twitter/parrot/config/ParrotServerConfig.scala
+++ b/src/main/scala/com/twitter/parrot/config/ParrotServerConfig.scala
@@ -109,6 +109,7 @@ trait ParrotServerConfig[Req <: ParrotRequest, Rep] extends Config[RuntimeEnviro
   var thriftClientId = ""
   var thriftProtocolFactory: Option[TProtocolFactory] = None
   var includeParrotHeader = true
+  var includeRandomXForwardedForHeader = true
 
   var thinkTime = 0L
   var replayTimeCheck = false

--- a/src/main/scala/com/twitter/parrot/launcher/ParrotLauncher.scala
+++ b/src/main/scala/com/twitter/parrot/launcher/ParrotLauncher.scala
@@ -86,6 +86,8 @@ class ParrotLauncher(config: ParrotLauncherConfig) {
     ("hostConnectionMaxLifeTimeInMs" -> config.hostConnectionMaxLifeTimeInMs.toString),
     ("httpHostHeaderPort" -> config.port.toString),
     ("imports" -> config.imports),
+    ("includeParrotHeader" -> config.includeParrotHeader.toString),
+    ("includeRandomXForwardedForHeader" -> config.includeRandomXForwardedForHeader.toString),
     ("jobName" -> pmode.jobName),
     ("loadTest" -> config.loadTest),
     ("logFile" -> pmode.logPath),
@@ -108,8 +110,7 @@ class ParrotLauncher(config: ParrotLauncherConfig) {
     ("timeUnit" -> config.timeUnit),
     ("traceLevel" -> config.traceLevel.toString),
     ("transport" -> transport),
-    ("victim" -> victim),
-    ("includeParrotHeader" -> config.includeParrotHeader.toString))
+    ("victim" -> victim))
 
   // a read only view of the symbols table for testing
   def readSymbols: Map[String, String] = symbols.toMap

--- a/src/main/scala/com/twitter/parrot/server/FinagleTransport.scala
+++ b/src/main/scala/com/twitter/parrot/server/FinagleTransport.scala
@@ -67,12 +67,12 @@ object FinagleTransportFactory extends ParrotTransportFactory[ParrotRequest, Htt
       else
         FinagleServiceFactory(builder3.buildFactory())
 
-    new FinagleTransport(service, config.includeParrotHeader)
+    new FinagleTransport(service, config)
   }
 }
 
 
-class FinagleTransport(service: FinagleServiceAbstraction, includeParrotHeader: Boolean)
+class FinagleTransport(service: FinagleServiceAbstraction, config: ParrotServerConfig[ParrotRequest, HttpResponse])
   extends ParrotTransport[ParrotRequest, HttpResponse] {
 
   var allRequests = 0
@@ -93,10 +93,12 @@ class FinagleTransport(service: FinagleServiceAbstraction, includeParrotHeader: 
       case (name, value) => name + "=" + value
     } mkString (";"))
     httpRequest.setHeader("User-Agent", "com.twitter.parrot")
-    if (includeParrotHeader) {
+    if (config.includeParrotHeader) {
       httpRequest.setHeader("X-Parrot", "true")
     }
-    httpRequest.setHeader("X-Forwarded-For", randomIp)
+    if (config.includeRandomXForwardedForHeader) {
+      httpRequest.setHeader("X-Forwarded-For", randomIp)
+    }
 
     if (request.method == "POST" && request.body.length > 0) {
       val buffer = ChannelBuffers.copiedBuffer(BIG_ENDIAN, request.body, UTF_8)


### PR DESCRIPTION
The x-forwarded-for header was causing requests to fail on our systems when it contained a random IP address. This patch makes the feature configurable, with the feature being enabled by default for backwards compatibility. 
