### PR TITLE
Make iago compatible with Scala 2.10.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,18 +34,10 @@
     </pluginRepository>
   </pluginRepositories>
   <dependencies>
-
-    <!-- Scala -->
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.9.2</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-library</artifactId>
-      <version>2.9.2</version>
+      <version>2.10.3</version>
     </dependency>
     <dependency>
       <groupId>com.twitter.common.zookeeper</groupId>
@@ -74,52 +66,52 @@
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>finagle-http_2.9.2</artifactId>
+      <artifactId>finagle-http_2.10</artifactId>
       <version>6.11.1</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>finagle-kestrel_2.9.2</artifactId>
+      <artifactId>finagle-kestrel_2.10</artifactId>
       <version>6.11.1</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>finagle-zipkin_2.9.2</artifactId>
+      <artifactId>finagle-zipkin_2.10</artifactId>
       <version>6.11.1</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>finagle-memcached_2.9.2</artifactId>
+      <artifactId>finagle-memcached_2.10</artifactId>
       <version>6.11.1</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>finagle-ostrich4_2.9.2</artifactId>
+      <artifactId>finagle-ostrich4_2.10</artifactId>
       <version>6.11.1</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>finagle-thrift_2.9.2</artifactId>
+      <artifactId>finagle-thrift_2.10</artifactId>
       <version>6.11.1</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>ostrich_2.9.2</artifactId>
+      <artifactId>ostrich_2.10</artifactId>
       <version>9.2.1</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>util-core_2.9.2</artifactId>
+      <artifactId>util-core_2.10</artifactId>
       <version>6.11.1</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>util-eval_2.9.2</artifactId>
+      <artifactId>util-eval_2.10</artifactId>
       <version>6.11.1</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>util-logging_2.9.2</artifactId>
+      <artifactId>util-logging_2.10</artifactId>
       <version>6.11.1</version>
     </dependency>
     <dependency>
@@ -135,7 +127,7 @@
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>scrooge-core_2.9.2</artifactId>
+      <artifactId>scrooge-core_2.10</artifactId>
       <version>3.12.2</version>
     </dependency>
     <dependency>
@@ -146,8 +138,8 @@
     <!-- Test -->
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.9.2</artifactId>
-      <version>1.9.1</version>
+      <artifactId>scalatest_2.10</artifactId>
+      <version>1.9.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/scala/com/twitter/parrot/config/ParrotFeederConfig.scala
+++ b/src/main/scala/com/twitter/parrot/config/ParrotFeederConfig.scala
@@ -49,13 +49,13 @@ trait ParrotFeederConfig extends Config[RuntimeEnvironment => Service]
 
     inputLog = runtime.arguments.getOrElse("log", inputLog)
 
-    var admin = new AdminServiceFactory (
+    var admin = AdminServiceFactory(
       adminPort,
-      statsNodes = new StatsFactory(
-        reporters = new JsonStatsLoggerFactory(
+      statsNodes = StatsFactory(
+        reporters = JsonStatsLoggerFactory(
           period = 1.minute,
           serviceName = statsName
-        ) :: new TimeSeriesCollectorFactory()
+        ) :: TimeSeriesCollectorFactory()
       )
     )(runtime)
 

--- a/src/main/scala/com/twitter/parrot/config/ParrotServerConfig.scala
+++ b/src/main/scala/com/twitter/parrot/config/ParrotServerConfig.scala
@@ -138,12 +138,12 @@ trait ParrotServerConfig[Req <: ParrotRequest, Rep] extends Config[RuntimeEnviro
     parrotPort = runtime.arguments.getOrElse("thriftPort", parrotPort.toString).toInt
     this.runtime = runtime
 
-    var admin = new AdminServiceFactory(
+    var admin = AdminServiceFactory(
       adminPort,
-      statsNodes = new StatsFactory(
-        reporters = new JsonStatsLoggerFactory(
+      statsNodes = StatsFactory(
+        reporters = JsonStatsLoggerFactory(
           period = 1.minute,
-          serviceName = statsName) :: new TimeSeriesCollectorFactory()))(runtime)
+          serviceName = statsName) :: TimeSeriesCollectorFactory()))(runtime)
 
     val server = new ParrotServerImpl(this)
 

--- a/src/main/scala/com/twitter/parrot/launcher/CommandRunner.scala
+++ b/src/main/scala/com/twitter/parrot/launcher/CommandRunner.scala
@@ -43,7 +43,7 @@ object CommandRunner {
       runner.run()
       runner.getOutput.length > 0
     } catch {
-      case _ => false
+      case _: Throwable => false
     }
   }
 
@@ -61,7 +61,7 @@ object CommandRunner {
   }
 }
 
-class CommandRunner(command: String, verbose: Boolean = verbose) {
+class CommandRunner(command: String, verbose: Boolean = false) {
   private[this] val process = Runtime.getRuntime.exec(command)
   private[this] val inputStream = process.getInputStream
   private[this] val errorStream = process.getErrorStream
@@ -154,7 +154,7 @@ class PasswordReader(stream: OutputStream) extends Callable[Unit] {
           running = false
         }
       } catch {
-        case _ => println("exception in password reader, continuing...")
+        case _: Throwable => println("exception in password reader, continuing...")
       }
     }
   }

--- a/src/main/scala/com/twitter/parrot/launcher/SMFProxy.scala
+++ b/src/main/scala/com/twitter/parrot/launcher/SMFProxy.scala
@@ -80,7 +80,7 @@ class SMFProxy(config: ParrotLauncherConfig) {
         val lsOutput = runner.getOutput
         val lsNextLine = lsOutput.split("""\n+""")(1)
         lsNextLine.split("""\s+""")(4).toLong / 1024 / 1024
-      } catch { case e => 0L }
+      } catch { case e: Throwable => 0L }
     } else if (status == 1) 0L
     else {
       runner.dumpOutput()

--- a/src/main/scala/com/twitter/parrot/server/FinagleTransport.scala
+++ b/src/main/scala/com/twitter/parrot/server/FinagleTransport.scala
@@ -48,7 +48,7 @@ object FinagleTransportFactory extends ParrotTransportFactory[ParrotRequest, Htt
       .tcpConnectTimeout(Duration(config.tcpConnectTimeoutInMs, TimeUnit.MILLISECONDS))
       .keepAlive(true)
       .reportTo(statsReceiver)
-      .tracer(ZipkinTracer.mk(statsReceiver = statsReceiver))
+      .tracer(ZipkinTracer.mk(statsReceiver))
 
     val builder2 = {
       if (config.transportScheme == config.TransportScheme.HTTPS)

--- a/src/main/scala/com/twitter/parrot/server/MemcacheLikeTransport.scala
+++ b/src/main/scala/com/twitter/parrot/server/MemcacheLikeTransport.scala
@@ -54,7 +54,7 @@ abstract class MemcacheLikeTransportFactory[Req, Rep] extends ParrotTransportFac
       .tcpConnectTimeout(Duration(config.tcpConnectTimeoutInMs, TimeUnit.MILLISECONDS))
       .keepAlive(true)
       .reportTo(statsReceiver)
-      .tracer(ZipkinTracer.mk(statsReceiver = statsReceiver))
+      .tracer(ZipkinTracer.mk(statsReceiver))
 
     val builder2 = {
       config.victim.value match {
@@ -88,7 +88,7 @@ class MemcacheLikeTransport[Req, Rep](
       result proxyTo response
       result
     } catch {
-      case e =>
+      case e: Throwable =>
         log.error(e, "error executing request %s", command)
         throw e
     }

--- a/src/main/scala/com/twitter/parrot/server/RefcountedService.scala
+++ b/src/main/scala/com/twitter/parrot/server/RefcountedService.scala
@@ -27,7 +27,7 @@ import com.twitter.util.{Future, Promise, Time}
 class RefcountedService[Req, Rep](underlying: Service[Req, Rep])
   extends ServiceProxy[Req, Rep](underlying)
 {
-  protected[this] val replyLatch = new AsyncLatch
+  protected[this] val replyLatch = new AsyncLatch()
 
   override def apply(request: Req) = {
     replyLatch.incr()

--- a/src/main/scala/com/twitter/parrot/server/RequestConsumer.scala
+++ b/src/main/scala/com/twitter/parrot/server/RequestConsumer.scala
@@ -89,7 +89,7 @@ class RequestConsumer[Req <: ParrotRequest, Rep](
         totalProcessed += 1
       }
     } catch {
-      case t =>
+      case t: Throwable =>
         log.error(t, "Exception sending request: %s", t)
     }
   }

--- a/src/main/scala/com/twitter/parrot/server/ThriftTransport.scala
+++ b/src/main/scala/com/twitter/parrot/server/ThriftTransport.scala
@@ -53,7 +53,7 @@ object ThriftTransportFactory extends ParrotTransportFactory[ParrotRequest, Arra
       .hostConnectionMaxLifeTime(Duration(config.hostConnectionMaxLifeTimeInMs,
         TimeUnit.MILLISECONDS))
       .reportTo(statsReceiver)
-      .tracer(ZipkinTracer.mk(statsReceiver = statsReceiver))
+      .tracer(ZipkinTracer.mk(statsReceiver))
 
     val builder2 = {
       if (config.transportScheme == config.TransportScheme.THRIFTS)

--- a/src/main/scala/com/twitter/parrot/util/ConsoleHandler.scala
+++ b/src/main/scala/com/twitter/parrot/util/ConsoleHandler.scala
@@ -68,7 +68,7 @@ object ConsoleHandler {
     (() => handle(prefix, Some(level)))
 
   def loggers(level0: Level = Level.INFO, prefix: String = "") = {
-    List(new LoggerFactory(
+    List(LoggerFactory(
       level = Some(level0),
       handlers = List(apply(level0, prefix))))
   }

--- a/src/main/scala/com/twitter/parrot/util/UriParser.scala
+++ b/src/main/scala/com/twitter/parrot/util/UriParser.scala
@@ -64,7 +64,7 @@ object UriParser {
         }
     }
     Return(Uri(uri.getPath, if (args.isEmpty) Nil else args))
-  } catch { case t =>
+  } catch { case t: Throwable =>
     Throw(t)
   }
 


### PR DESCRIPTION
Here are the changes necessary to make iago compile with Scala 2.10.3.  This can be helpful for those dealing with binary incompatibilities between Scala 2.9 and 2.10.
