### PR TITLE
Use single brackets instead of double in common.sh

### DIFF
--- a/src/main/resources/scripts/common.sh
+++ b/src/main/resources/scripts/common.sh
@@ -1,6 +1,6 @@
 # common.sh
 
-if [[ -z $JAVA_HOME ]]; then
+if [ -z $JAVA_HOME ]; then
   potential=$(ls -r1d /usr/lib/jvm/java-1.7.0-openjdk7 /opt/jdk /System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK/Home /usr/java/default /usr/java/j* 2>/dev/null)
   for p in $potential; do
     if [ -x $p/bin/java ]; then


### PR DESCRIPTION
On Ubuntu, I get the following errors when running the examples:
stderr: scripts/parrot-server.sh: 3: scripts/common.sh: [[: not found
stderr: scripts/parrot-feeder.sh: 3: scripts/common.sh: [[: not found

According to http://stackoverflow.com/questions/9666102/bash-double-bracket-issue, the sh command on Ubuntu does not support double brackets. Using single brackets fixes the problem. 
