### PR TITLE
Added PUT support to FinagleTransport

### DIFF
--- a/src/main/scala/com/twitter/parrot/server/FinagleTransport.scala
+++ b/src/main/scala/com/twitter/parrot/server/FinagleTransport.scala
@@ -81,6 +81,7 @@ class FinagleTransport(service: FinagleServiceAbstraction, config: ParrotServerC
   override protected[server] def sendRequest(request: ParrotRequest): Future[HttpResponse] = {
     val requestMethod = request.method match {
       case "POST" => HttpMethod.POST
+      case "PUT"  => HttpMethod.PUT
       case _      => HttpMethod.GET
     }
     val httpRequest =
@@ -100,7 +101,7 @@ class FinagleTransport(service: FinagleServiceAbstraction, config: ParrotServerC
       httpRequest.setHeader("X-Forwarded-For", randomIp)
     }
 
-    if (request.method == "POST" && request.body.length > 0) {
+    if ((request.method == "POST" || request.method == "PUT") && request.body.length > 0) {
       val buffer = ChannelBuffers.copiedBuffer(BIG_ENDIAN, request.body, UTF_8)
       httpRequest.setHeader(CONTENT_LENGTH, buffer.readableBytes)
       httpRequest.setContent(buffer)


### PR DESCRIPTION
Added PUT support. Request body supported added for PUT as it will contain a newly-updated representation of an original resource or even possibly a new resource.

It was easier to add these 2 lines of code than have to extend ParrotTransport and create my own.  Someone else in the community may require PUT for content create / update.
