### PR TITLE
Fix bug in ParrotCluster shutdown

### DIFF
--- a/src/main/scala/com/twitter/parrot/util/ParrotCluster.scala
+++ b/src/main/scala/com/twitter/parrot/util/ParrotCluster.scala
@@ -318,8 +318,6 @@ class ParrotClusterImpl(config: Option[ParrotCommonConfig] = None)
     config.get.zkHostName foreach { host => discovery.shutdown() }
 
     val allParrots = parrots
-    _runningParrots.clear()
-    _pausedParrots.clear()
     allParrots foreach { parrot =>
       try {
         parrot.shutdown()
@@ -328,6 +326,8 @@ class ParrotClusterImpl(config: Option[ParrotCommonConfig] = None)
         case t: Throwable => log.error(t, "Error shutting down Parrot: %s", t.getClass.getName)
       }
     }
+    _runningParrots.clear()
+    _pausedParrots.clear()
   }
 
   def pause() {


### PR DESCRIPTION
When the ParrotFeeder starts the shutdown process because it has satisfied the config requirements, it calls cluster.shutdown(), which clears the list of remoteParrots.
ParrotPoller which keeps monitoring the ParrotServer queues now loses track & never updates the local queue state, this results in the servers being considered as permanently busy (isBusy = qDepth > targetDepth)

This fix is intended to move the clearing of remoteParrots after the servers have actually shutdown & not prematurely.
