### PR TITLE
Resolve transitive dependency conflict for commons-codec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
       <version>2.2</version>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <!-- explicitly provide highest of versions required by transitive dependencies -->
+      <version>1.6</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.6.1</version>


### PR DESCRIPTION
Explicitly declare commons-codec dependency in iago parent pom to avoid version conflict between several transitive dependencies.

One of the lowest versions in this conflict (1.3) currently wins in the dependency tree resolution (see output of `mvn dependency:tree -Dverbose -Dincludes=commons-codec`). This breaks a call to `Base64.encodeAsString(byte[])` in `com.twitter.util.StringEncoder`, which is not supported by the resolved version.