### PR TITLE
Add support for specifying ParrotRequest body as a ByteArrayInputStream

### DIFF
--- a/src/main/scala/com/twitter/parrot/server/ParrotRequest.scala
+++ b/src/main/scala/com/twitter/parrot/server/ParrotRequest.scala
@@ -30,6 +30,7 @@ class ParrotRequest(
   val cookies: Seq[(String, String)] = Seq(),
   val method: String = "GET",
   val body: String = "",
+  val bodyInputStream: Option[java.io.ByteArrayInputStream] = None,
   val weight: Int = 1
   ) {
   val headers: Seq[(String, String)] =


### PR DESCRIPTION
This allows sending parrot requests with a body that are to be interpreted as Content-Type: application/octet-stream.

The choice of requiring a ByteArrayInputStream vs any InputStream was simply because it made the allocation of the ChannelBuffer simple, because then InputStream.available() can be used reliably, and in favor over more complex allocation/copying of the InputStream to a Netty ChannelBuffer.
