### PR TITLE
Make the iago-echo example use scala 2.10.3

### DIFF
--- a/examples/echo/pom.xml
+++ b/examples/echo/pom.xml
@@ -32,6 +32,11 @@
       <artifactId>iago</artifactId>
       <version>0.6.14</version>
     </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.10.3</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
Add the scala 2.10.3 dependency the iago-echo's pom.xml.

It fixes the known issue reported at
https://github.com/twitter/iago/issues/35
https://groups.google.com/forum/#!msg/iago-users/Hbrcne12zBg/0OoSX1HEGr8J